### PR TITLE
fix(agent): tests have enabled field as int not bool

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -16,7 +16,7 @@ type Agent struct {
 	ErrorDetails          []AgentErrorDetails `json:"errorDetails,omitempty"`
 	Hostname              string              `json:"hostname,omitempty"`
 	Prefix                string              `json:"prefix,omitempty"`
-	Enabled               bool                `json:"enabled,omitempty"`
+	Enabled               int                 `json:"enabled,omitempty"`
 	Network               string              `json:"network,omitempty"`
 	CreatedDate           string              `json:"createdDate,omitempty"`
 	LastSeen              string              `json:"lastSeen,omitempty"`

--- a/agent_test.go
+++ b/agent_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestClient_GetAgents(t *testing.T) {
-	out := `{"agents":[{"agentId": 1}, {"agentId": 2}]}`
+	out := `{"agents":[{"agentId": 1, "enabled": 1}, {"agentId": 2, "enabled": 0}]}`
 	setup()
 	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/agents.json", func(w http.ResponseWriter, r *http.Request) {
@@ -19,9 +19,11 @@ func TestClient_GetAgents(t *testing.T) {
 	expected := Agents{
 		Agent{
 			AgentId: 1,
+			Enabled: 1,
 		},
 		Agent{
 			AgentId: 2,
+			Enabled: 0,
 		},
 	}
 	res, err := client.GetAgents()


### PR DESCRIPTION
## What

* moved enabled to int from bool
* updated tests to include the enabled flag

## Why

* [bug][2] raised terraform-provider-thousandeyes fails to marshal into struct due to field being a int not bool. 

## References

* [API Docs][1]
* [Terraform provider bug][2]

[1]: https://developer.thousandeyes.com/v6/tests/
[2]: https://github.com/william20111/terraform-provider-thousandeyes/issues/4