### PR TITLE
feat(ftp-server): add support for ftp server test

### DIFF
--- a/bgp_monitor_test.go
+++ b/bgp_monitor_test.go
@@ -1,7 +1,6 @@
 package thousandeyes
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -23,7 +22,6 @@ func TestClient_GetBGPMonitors(t *testing.T) {
 	}
 
 	res, err := client.GetBPGMonitors()
-	fmt.Println(res)
 	teardown()
 	assert.Nil(t, err)
 	assert.Equal(t, &expected, res)

--- a/bgp_test.go
+++ b/bgp_test.go
@@ -100,7 +100,6 @@ func TestClient_CreateBGP(t *testing.T) {
 	})
 
 	// Define expected values from the API (based on the JSON we print out above)
-	// Define expected values from the API (based on the JSON we print out above)
 	expected := BGP{
 
 		TestID:        122621,

--- a/ftp_server.go
+++ b/ftp_server.go
@@ -1,15 +1,8 @@
 package thousandeyes
 
-import (
-	"fmt"
-)
+import "fmt"
 
-type Server struct {
-	ServerID   int    `json:"serverId,omitempty"`
-	ServerName string `json:"serverName,omitempty"`
-}
-
-type DNSServer struct {
+type FTPServer struct {
 	Agents                []Agent        `json:"agents,omitempty"`
 	AlertsEnabled         int            `json:"alertsEnabled,omitempty"`
 	AlertRules            []AlertRule    `json:"alertRules,omitempty"`
@@ -29,74 +22,79 @@ type DNSServer struct {
 	Type                  string         `json:"type,omitempty"`
 	BandwidthMeasurements int            `json:"bandwidthMeasurements,omitempty"`
 	BgpMeasurements       int            `json:"bgpMeasurements,omitempty"`
-	BgpMonitors           []Monitor      `json:"bgpMonitors,omitempty"`
-	DNSServers            []Server       `json:"dnsServers,omitempty"`
-	DNSTransportProtocol  string         `json:"dnsTransportProtocol,omitempty"`
 	Domain                string         `json:"domain,omitempty"`
-	Interval              int            `json:"interval,omitempty"`
 	MtuMeasurements       int            `json:"mtuMeasurements,omitempty"`
 	NetworkMeasurements   int            `json:"networkMeasurements,omitempty"`
 	NumPathTraces         int            `json:"numPathTraces,omitempty"`
-	ProbeMode             string         `json:"probeMode,omitempty"`
 	Protocol              string         `json:"protocol,omitempty"`
-	RecursiveQueries      int            `json:"recursiveQueries,omitempty"`
+	DownloadLimit         int            `json:"downloadLimit,omitempty"`
+	FtpTargetTime         int            `json:"ftpTargetTime,omitempty"`
+	FtpTimeLimit          int            `json:"ftpTimeLimit,omitempty"`
+	Password              string         `json:"password,omitempty"`
+	PathTraceMode         string         `json:"pathTraceMode,omitempty"`
+	ProbeMode             string         `json:"probeMode,omitempty"`
+	RequestType           string         `json:"requestType,omitempty"`
+	Url                   string         `json:"url,omitempty"`
+	UseActiveFtp          int            `json:"useActiveFtp,omitempty"`
+	UseExplicitFtps       int            `json:"useExplicitFtps,omitempty"`
+	Username              string         `json:"username,omitempty"`
 }
 
-// AddAgent - Add dns server test
-func (t *DNSServer) AddAgent(id int) {
+// AddAgent - Add ftp server test
+func (t *FTPServer) AddAgent(id int) {
 	agent := Agent{AgentId: id}
 	t.Agents = append(t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *DNSServer) AddAlertRule(id int) {
+func (t *FTPServer) AddAlertRule(id int) {
 	alertRule := AlertRule{RuleId: id}
 	t.AlertRules = append(t.AlertRules, alertRule)
 }
 
-// GetDNSServer - get dns server test
-func (c *Client) GetDNSServer(id int) (*DNSServer, error) {
+// GetFTPServer - get ftp server test
+func (c *Client) GetFTPServer(id int) (*FTPServer, error) {
 	resp, err := c.get(fmt.Sprintf("/tests/%d", id))
 	if err != nil {
-		return &DNSServer{}, err
+		return &FTPServer{}, err
 	}
-	var target map[string][]DNSServer
+	var target map[string][]FTPServer
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
 		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
 	}
 	return &target["test"][0], nil
 }
 
-// CreateDNSServer - Create dns server test
-func (c Client) CreateDNSServer(t DNSServer) (*DNSServer, error) {
-	resp, err := c.post("/tests/dns-server/new", t, nil)
+// CreateFTPServer - Create ftp server test
+func (c Client) CreateFTPServer(t FTPServer) (*FTPServer, error) {
+	resp, err := c.post("/tests/ftp-server/new", t, nil)
 	if err != nil {
 		return &t, err
 	}
 	if resp.StatusCode != 201 {
 		return &t, fmt.Errorf("failed to create test, response code %d", resp.StatusCode)
 	}
-	var target map[string][]DNSServer
+	var target map[string][]FTPServer
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
 		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
 	}
 	return &target["test"][0], nil
 }
 
-//DeleteDNSServer - delete dns server test
-func (c *Client) DeleteDNSServer(id int) error {
-	resp, err := c.post(fmt.Sprintf("/tests/dns-server/%d/delete", id), nil, nil)
+//DeleteFTPServer - delete ftp server test
+func (c *Client) DeleteFTPServer(id int) error {
+	resp, err := c.post(fmt.Sprintf("/tests/ftp-server/%d/delete", id), nil, nil)
 	if err != nil {
 		return err
 	}
 	if resp.StatusCode != 204 {
-		return fmt.Errorf("failed to delete dns server test, response code %d", resp.StatusCode)
+		return fmt.Errorf("failed to delete ftp server test, response code %d", resp.StatusCode)
 	}
 	return nil
 }
 
-//UpdateDNSServer - - Update dns server test
-func (c *Client) UpdateDNSServer(id int, t DNSServer) (*DNSServer, error) {
+//UpdateFTPServer - - Update ftp server test
+func (c *Client) UpdateFTPServer(id int, t FTPServer) (*FTPServer, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/dns-server/%d/update", id), t, nil)
 	if err != nil {
 		return &t, err
@@ -104,7 +102,7 @@ func (c *Client) UpdateDNSServer(id int, t DNSServer) (*DNSServer, error) {
 	if resp.StatusCode != 200 {
 		return &t, fmt.Errorf("failed to update test, response code %d", resp.StatusCode)
 	}
-	var target map[string][]DNSServer
+	var target map[string][]FTPServer
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
 		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
 	}

--- a/ftp_server.go
+++ b/ftp_server.go
@@ -6,7 +6,7 @@ type FTPServer struct {
 	Agents                []Agent        `json:"agents,omitempty"`
 	AlertsEnabled         int            `json:"alertsEnabled,omitempty"`
 	AlertRules            []AlertRule    `json:"alertRules,omitempty"`
-	ApiLinks              []ApiLink      `json:"apiLinks,omitempty"`
+	APILinks              []ApiLink      `json:"apiLinks,omitempty"`
 	CreatedBy             string         `json:"createdBy,omitempty"`
 	CreatedDate           string         `json:"createdDate,omitempty"`
 	Description           string         `json:"description,omitempty"`
@@ -17,12 +17,11 @@ type FTPServer struct {
 	ModifiedDate          string         `json:"modifiedDate,omitempty"`
 	SavedEvent            int            `json:"savedEvent,omitempty"`
 	SharedWithAccounts    []AccountGroup `json:"sharedWithAccounts,omitempty"`
-	TestId                int            `json:"testId,omitempty"`
+	TestID                int            `json:"testId,omitempty"`
 	TestName              string         `json:"testName,omitempty"`
 	Type                  string         `json:"type,omitempty"`
 	BandwidthMeasurements int            `json:"bandwidthMeasurements,omitempty"`
 	BgpMeasurements       int            `json:"bgpMeasurements,omitempty"`
-	Domain                string         `json:"domain,omitempty"`
 	MtuMeasurements       int            `json:"mtuMeasurements,omitempty"`
 	NetworkMeasurements   int            `json:"networkMeasurements,omitempty"`
 	NumPathTraces         int            `json:"numPathTraces,omitempty"`
@@ -72,7 +71,7 @@ func (c Client) CreateFTPServer(t FTPServer) (*FTPServer, error) {
 		return &t, err
 	}
 	if resp.StatusCode != 201 {
-		return &t, fmt.Errorf("failed to create test, response code %d", resp.StatusCode)
+		return &t, fmt.Errorf("failed to create ftp test, response code %d", resp.StatusCode)
 	}
 	var target map[string][]FTPServer
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
@@ -95,12 +94,12 @@ func (c *Client) DeleteFTPServer(id int) error {
 
 //UpdateFTPServer - - Update ftp server test
 func (c *Client) UpdateFTPServer(id int, t FTPServer) (*FTPServer, error) {
-	resp, err := c.post(fmt.Sprintf("/tests/dns-server/%d/update", id), t, nil)
+	resp, err := c.post(fmt.Sprintf("/tests/ftp-server/%d/update", id), t, nil)
 	if err != nil {
 		return &t, err
 	}
 	if resp.StatusCode != 200 {
-		return &t, fmt.Errorf("failed to update test, response code %d", resp.StatusCode)
+		return &t, fmt.Errorf("failed to update ftp test, response code %d", resp.StatusCode)
 	}
 	var target map[string][]FTPServer
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {

--- a/ftp_server.go
+++ b/ftp_server.go
@@ -2,11 +2,12 @@ package thousandeyes
 
 import "fmt"
 
+// FTPServer - ftp server test
 type FTPServer struct {
 	Agents                []Agent        `json:"agents,omitempty"`
 	AlertsEnabled         int            `json:"alertsEnabled,omitempty"`
 	AlertRules            []AlertRule    `json:"alertRules,omitempty"`
-	APILinks              []ApiLink      `json:"apiLinks,omitempty"`
+	APILinks              []APILink      `json:"apiLinks,omitempty"`
 	CreatedBy             string         `json:"createdBy,omitempty"`
 	CreatedDate           string         `json:"createdDate,omitempty"`
 	Description           string         `json:"description,omitempty"`
@@ -33,7 +34,7 @@ type FTPServer struct {
 	PathTraceMode         string         `json:"pathTraceMode,omitempty"`
 	ProbeMode             string         `json:"probeMode,omitempty"`
 	RequestType           string         `json:"requestType,omitempty"`
-	Url                   string         `json:"url,omitempty"`
+	URL                   string         `json:"url,omitempty"`
 	UseActiveFtp          int            `json:"useActiveFtp,omitempty"`
 	UseExplicitFtps       int            `json:"useExplicitFtps,omitempty"`
 	Username              string         `json:"username,omitempty"`
@@ -41,13 +42,13 @@ type FTPServer struct {
 
 // AddAgent - Add ftp server test
 func (t *FTPServer) AddAgent(id int) {
-	agent := Agent{AgentId: id}
+	agent := Agent{AgentID: id}
 	t.Agents = append(t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
 func (t *FTPServer) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleId: id}
+	alertRule := AlertRule{RuleID: id}
 	t.AlertRules = append(t.AlertRules, alertRule)
 }
 
@@ -80,7 +81,7 @@ func (c Client) CreateFTPServer(t FTPServer) (*FTPServer, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteFTPServer - delete ftp server test
+// DeleteFTPServer - delete ftp server test
 func (c *Client) DeleteFTPServer(id int) error {
 	resp, err := c.post(fmt.Sprintf("/tests/ftp-server/%d/delete", id), nil, nil)
 	if err != nil {
@@ -92,7 +93,7 @@ func (c *Client) DeleteFTPServer(id int) error {
 	return nil
 }
 
-//UpdateFTPServer - - Update ftp server test
+// UpdateFTPServer - - Update ftp server test
 func (c *Client) UpdateFTPServer(id int, t FTPServer) (*FTPServer, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/ftp-server/%d/update", id), t, nil)
 	if err != nil {

--- a/ftp_server_test.go
+++ b/ftp_server_test.go
@@ -1,0 +1,1 @@
+package thousandeyes

--- a/ftp_server_test.go
+++ b/ftp_server_test.go
@@ -26,7 +26,7 @@ func TestClient_GetFTPServer(t *testing.T) {
 		TestName:      "test123",
 		Type:          "ftp-server",
 		Url:           "webex.com",
-		Protocol:      "TCP",
+		ProbeMode:     "AUTO",
 		Agents: []Agent{
 			{
 				AgentId:     48620,
@@ -89,7 +89,7 @@ func TestClient_GetFTPServerJsonError(t *testing.T) {
 }
 
 func TestClient_CreateFTPServer(t *testing.T) {
-	out := `{"test":[{"createdDate":"2020-02-06 15:28:07","createdBy":"William Fleming (wfleming@grumpysysadm.com)","enabled":1,"savedEvent":0,"testId":122621,"testName":"test123","type":"ftp-server","alertsEnabled":1,"liveShare":0,"probeMode":"AUTO","agents":[{"agentId":48620,"agentName":"Seattle, WA (Trial) - IPv6","agentType":"Cloud","countryId":"US","ipAddresses":["135.84.184.153"],"location":"Seattle Area","network":"Astute Hosting Inc. (AS 54527)","prefix":"135.84.184.0/22"}],"sharedWithAccounts":[{"aid":176592,"name":"Cloudreach"}],"domain": "url.com","apiLinks":[{"rel":"self","href":"https://api.thousandeyes.com/v6/tests/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/web/ftp-server/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/metrics/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/path-vis/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/bgp-metrics/1226221"}]}]}`
+	out := `{"test":[{"createdDate":"2020-02-06 15:28:07","createdBy":"William Fleming (wfleming@grumpysysadm.com)","enabled":1,"savedEvent":0,"testId":122621,"testName":"test123","type":"ftp-server","interval":300,"alertsEnabled":1,"liveShare":0,"protocol": "TCP","probeMode":"AUTO","agents":[{"agentId":48620,"agentName":"Seattle, WA (Trial) - IPv6","agentType":"Cloud","countryId":"US","ipAddresses":["135.84.184.153"],"location":"Seattle Area","network":"Astute Hosting Inc. (AS 54527)","prefix":"135.84.184.0/22"}],"sharedWithAccounts":[{"aid":176592,"name":"Cloudreach"}],"url": "webex.com","apiLinks":[{"rel":"self","href":"https://api.thousandeyes.com/v6/tests/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/web/ftp-server/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/metrics/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/path-vis/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/bgp-metrics/1226221"}]}]}`
 	setup()
 	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/ftp-server/new.json", func(w http.ResponseWriter, r *http.Request) {
@@ -110,6 +110,7 @@ func TestClient_CreateFTPServer(t *testing.T) {
 		AlertsEnabled: 1,
 		Url:           "webex.com",
 		Protocol:      "TCP",
+		ProbeMode:     "AUTO",
 		Agents: []Agent{
 			{
 				AgentId:     48620,
@@ -152,12 +153,13 @@ func TestClient_CreateFTPServer(t *testing.T) {
 			},
 		},
 	}
-	create := DNSTrace{
-		TestName: "test1",
-		Domain:   "1.1.1.1",
-		Interval: 300,
+	create := FTPServer{
+		TestName:  "test123",
+		Url:       "webex.com",
+		Protocol:  "TCP",
+		ProbeMode: "AUTO",
 	}
-	res, err := client.CreateDNSTrace(create)
+	res, err := client.CreateFTPServer(create)
 	teardown()
 	assert.Nil(t, err)
 	assert.Equal(t, &expected, res)

--- a/ftp_server_test.go
+++ b/ftp_server_test.go
@@ -9,7 +9,7 @@ import (
 func TestClient_GetFTPServer(t *testing.T) {
 	out := `{"test":[{"createdDate":"2020-02-06 15:28:07","createdBy":"William Fleming (wfleming@grumpysysadm.com)","enabled":1,"savedEvent":0,"testId":122621,"testName":"test123","type":"ftp-server","interval":300,"alertsEnabled":1,"liveShare":0,"probeMode":"AUTO","agents":[{"agentId":48620,"agentName":"Seattle, WA (Trial) - IPv6","agentType":"Cloud","countryId":"US","ipAddresses":["135.84.184.153"],"location":"Seattle Area","network":"Astute Hosting Inc. (AS 54527)","prefix":"135.84.184.0/22"}],"sharedWithAccounts":[{"aid":176592,"name":"Cloudreach"}],"url": "webex.com","apiLinks":[{"rel":"self","href":"https://api.thousandeyes.com/v6/tests/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/web/ftp-server/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/metrics/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/path-vis/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/bgp-metrics/1226221"}]}]}`
 	setup()
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/122621.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		_, _ = w.Write([]byte(out))
@@ -25,21 +25,21 @@ func TestClient_GetFTPServer(t *testing.T) {
 		AlertsEnabled: 1,
 		TestName:      "test123",
 		Type:          "ftp-server",
-		Url:           "webex.com",
+		URL:           "webex.com",
 		ProbeMode:     "AUTO",
 		Agents: []Agent{
 			{
-				AgentId:     48620,
+				AgentID:     48620,
 				AgentType:   "Cloud",
 				AgentName:   "Seattle, WA (Trial) - IPv6",
-				CountryId:   "US",
-				IpAddresses: []string{"135.84.184.153"},
+				CountryID:   "US",
+				IPAddresses: []string{"135.84.184.153"},
 				Location:    "Seattle Area",
 				Network:     "Astute Hosting Inc. (AS 54527)",
 				Prefix:      "135.84.184.0/22",
 			},
 		},
-		APILinks: []ApiLink{
+		APILinks: []APILink{
 			{
 				Href: "https://api.thousandeyes.com/v6/tests/1226221",
 				Rel:  "self",
@@ -78,7 +78,7 @@ func TestClient_GetFTPServer(t *testing.T) {
 func TestClient_GetFTPServerJsonError(t *testing.T) {
 	out := `{"test":[{"createdDate":"2020-02-06 15:28:07",createdBy":"William Fleming (wfleming@grumpysysadm.com)","enabled":1,"savedEvent":0,"testId":122621,"testName":"test123","type":"ftp-server","interval":300,"alertsEnabled":1,"liveShare":0,"probeMode":"AUTO","agents":[{"agentId":48620,"agentName":"Seattle, WA (Trial) - IPv6","agentType":"Cloud","countryId":"US","ipAddresses":["135.84.184.153"],"location":"Seattle Area","network":"Astute Hosting Inc. (AS 54527)","prefix":"135.84.184.0/22"}],"sharedWithAccounts":[{"aid":176592,"name":"Cloudreach"}],"domain": "webex.com","dnsTransportProtocol":  "UDP"}]"apiLinks":[{"rel":"self","href":"https://api.thousandeyes.com/v6/tests/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/web/dns-trace/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/metrics/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/path-vis/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/bgp-metrics/1226221"}]}]}`
 	setup()
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/122621.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		_, _ = w.Write([]byte(out))
@@ -91,7 +91,7 @@ func TestClient_GetFTPServerJsonError(t *testing.T) {
 func TestClient_CreateFTPServer(t *testing.T) {
 	out := `{"test":[{"createdDate":"2020-02-06 15:28:07","createdBy":"William Fleming (wfleming@grumpysysadm.com)","enabled":1,"savedEvent":0,"testId":122621,"testName":"test123","type":"ftp-server","interval":300,"alertsEnabled":1,"liveShare":0,"protocol": "TCP","probeMode":"AUTO","agents":[{"agentId":48620,"agentName":"Seattle, WA (Trial) - IPv6","agentType":"Cloud","countryId":"US","ipAddresses":["135.84.184.153"],"location":"Seattle Area","network":"Astute Hosting Inc. (AS 54527)","prefix":"135.84.184.0/22"}],"sharedWithAccounts":[{"aid":176592,"name":"Cloudreach"}],"url": "webex.com","apiLinks":[{"rel":"self","href":"https://api.thousandeyes.com/v6/tests/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/web/ftp-server/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/metrics/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/path-vis/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/bgp-metrics/1226221"}]}]}`
 	setup()
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/ftp-server/new.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
 		w.WriteHeader(http.StatusCreated)
@@ -108,16 +108,16 @@ func TestClient_CreateFTPServer(t *testing.T) {
 		TestName:      "test123",
 		Type:          "ftp-server",
 		AlertsEnabled: 1,
-		Url:           "webex.com",
+		URL:           "webex.com",
 		Protocol:      "TCP",
 		ProbeMode:     "AUTO",
 		Agents: []Agent{
 			{
-				AgentId:     48620,
+				AgentID:     48620,
 				AgentType:   "Cloud",
 				AgentName:   "Seattle, WA (Trial) - IPv6",
-				CountryId:   "US",
-				IpAddresses: []string{"135.84.184.153"},
+				CountryID:   "US",
+				IPAddresses: []string{"135.84.184.153"},
 				Location:    "Seattle Area",
 				Network:     "Astute Hosting Inc. (AS 54527)",
 				Prefix:      "135.84.184.0/22",
@@ -130,7 +130,7 @@ func TestClient_CreateFTPServer(t *testing.T) {
 			},
 		},
 
-		APILinks: []ApiLink{
+		APILinks: []APILink{
 			{
 				Href: "https://api.thousandeyes.com/v6/tests/1226221",
 				Rel:  "self",
@@ -155,7 +155,7 @@ func TestClient_CreateFTPServer(t *testing.T) {
 	}
 	create := FTPServer{
 		TestName:  "test123",
-		Url:       "webex.com",
+		URL:       "webex.com",
 		Protocol:  "TCP",
 		ProbeMode: "AUTO",
 	}
@@ -173,7 +173,7 @@ func TestClient_DeleteFTPServer(t *testing.T) {
 		assert.Equal(t, "POST", r.Method)
 	})
 
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	id := 1
 	err := client.DeleteFTPServer(id)
 
@@ -184,7 +184,7 @@ func TestClient_DeleteFTPServer(t *testing.T) {
 
 func TestClient_AddFTPServerAlertRule(t *testing.T) {
 	test := FTPServer{TestName: "test", AlertRules: []AlertRule{}}
-	expected := FTPServer{TestName: "test", AlertRules: []AlertRule{{RuleId: 1}}}
+	expected := FTPServer{TestName: "test", AlertRules: []AlertRule{{RuleID: 1}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -197,28 +197,28 @@ func TestClient_UpdateFTPServer(t *testing.T) {
 		_, _ = w.Write([]byte(out))
 	})
 
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	id := 1
-	ftpServer := FTPServer{Url: "webex.com"}
+	ftpServer := FTPServer{URL: "webex.com"}
 	res, err := client.UpdateFTPServer(id, ftpServer)
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := FTPServer{TestID: 1, TestName: "test123", Type: "ftp-server", Url: "webex.com"}
+	expected := FTPServer{TestID: 1, TestName: "test123", Type: "ftp-server", URL: "webex.com"}
 	assert.Equal(t, &expected, res)
 
 }
 
 func TestFTPServer_AddAgent(t *testing.T) {
 	test := FTPServer{TestName: "test", Agents: Agents{}}
-	expected := FTPServer{TestName: "test", Agents: []Agent{{AgentId: 1}}}
+	expected := FTPServer{TestName: "test", Agents: []Agent{{AgentID: 1}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }
 
 func TestClient_GetFTPServerError(t *testing.T) {
 	setup()
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/ftp-server/1.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		w.WriteHeader(http.StatusBadRequest)
@@ -232,11 +232,11 @@ func TestClient_GetFTPServerError(t *testing.T) {
 func TestClient_GetFTPServerStatusCode(t *testing.T) {
 	setup()
 	out := `{"test":[{"testId":1,"testName":"test123","type":"ftp-server"}]}`
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/1.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(out))
+		_, _ = w.Write([]byte(out))
 	})
 
 	_, err := client.GetFTPServer(1)
@@ -246,11 +246,11 @@ func TestClient_GetFTPServerStatusCode(t *testing.T) {
 
 func TestClient_CreateFTPServerStatusCode(t *testing.T) {
 	setup()
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/ftp-server/new.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	_, err := client.CreateFTPServer(FTPServer{})
 	teardown()
@@ -259,11 +259,11 @@ func TestClient_CreateFTPServerStatusCode(t *testing.T) {
 
 func TestClient_UpdateFTPServerStatusCode(t *testing.T) {
 	setup()
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/ftp-server/1/update.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	_, err := client.UpdateFTPServer(1, FTPServer{})
 	teardown()
@@ -272,11 +272,11 @@ func TestClient_UpdateFTPServerStatusCode(t *testing.T) {
 
 func TestClient_DeleteFTPServerCode(t *testing.T) {
 	setup()
-	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/tests/ftp-server/1/delete.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	err := client.DeleteFTPServer(1)
 	teardown()

--- a/ftp_server_test.go
+++ b/ftp_server_test.go
@@ -1,1 +1,282 @@
 package thousandeyes
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestClient_GetFTPServer(t *testing.T) {
+	out := `{"test":[{"createdDate":"2020-02-06 15:28:07","createdBy":"William Fleming (wfleming@grumpysysadm.com)","enabled":1,"savedEvent":0,"testId":122621,"testName":"test123","type":"ftp-server","interval":300,"alertsEnabled":1,"liveShare":0,"probeMode":"AUTO","agents":[{"agentId":48620,"agentName":"Seattle, WA (Trial) - IPv6","agentType":"Cloud","countryId":"US","ipAddresses":["135.84.184.153"],"location":"Seattle Area","network":"Astute Hosting Inc. (AS 54527)","prefix":"135.84.184.0/22"}],"sharedWithAccounts":[{"aid":176592,"name":"Cloudreach"}],"url": "webex.com","apiLinks":[{"rel":"self","href":"https://api.thousandeyes.com/v6/tests/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/web/ftp-server/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/metrics/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/path-vis/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/bgp-metrics/1226221"}]}]}`
+	setup()
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	mux.HandleFunc("/tests/122621.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		_, _ = w.Write([]byte(out))
+	})
+
+	// Define expected values from the API (based on the JSON we print out above)
+	expected := FTPServer{
+		TestID:        122621,
+		Enabled:       1,
+		CreatedBy:     "William Fleming (wfleming@grumpysysadm.com)",
+		CreatedDate:   "2020-02-06 15:28:07",
+		SavedEvent:    0,
+		AlertsEnabled: 1,
+		TestName:      "test123",
+		Type:          "ftp-server",
+		Url:           "webex.com",
+		Protocol:      "TCP",
+		Agents: []Agent{
+			{
+				AgentId:     48620,
+				AgentType:   "Cloud",
+				AgentName:   "Seattle, WA (Trial) - IPv6",
+				CountryId:   "US",
+				IpAddresses: []string{"135.84.184.153"},
+				Location:    "Seattle Area",
+				Network:     "Astute Hosting Inc. (AS 54527)",
+				Prefix:      "135.84.184.0/22",
+			},
+		},
+		APILinks: []ApiLink{
+			{
+				Href: "https://api.thousandeyes.com/v6/tests/1226221",
+				Rel:  "self",
+			},
+			{
+				Href: "https://api.thousandeyes.com/v6/web/ftp-server/1226221",
+				Rel:  "data",
+			},
+			{
+				Href: "https://api.thousandeyes.com/v6/net/metrics/1226221",
+				Rel:  "data",
+			},
+			{
+				Href: "https://api.thousandeyes.com/v6/net/path-vis/1226221",
+				Rel:  "data",
+			},
+			{
+				Href: "https://api.thousandeyes.com/v6/net/bgp-metrics/1226221",
+				Rel:  "data",
+			},
+		},
+		SharedWithAccounts: []AccountGroup{
+			{
+				Aid:  176592,
+				Name: "Cloudreach",
+			},
+		},
+	}
+
+	res, err := client.GetFTPServer(122621)
+	teardown()
+	assert.Nil(t, err)
+	assert.Equal(t, &expected, res)
+}
+
+func TestClient_GetFTPServerJsonError(t *testing.T) {
+	out := `{"test":[{"createdDate":"2020-02-06 15:28:07",createdBy":"William Fleming (wfleming@grumpysysadm.com)","enabled":1,"savedEvent":0,"testId":122621,"testName":"test123","type":"ftp-server","interval":300,"alertsEnabled":1,"liveShare":0,"probeMode":"AUTO","agents":[{"agentId":48620,"agentName":"Seattle, WA (Trial) - IPv6","agentType":"Cloud","countryId":"US","ipAddresses":["135.84.184.153"],"location":"Seattle Area","network":"Astute Hosting Inc. (AS 54527)","prefix":"135.84.184.0/22"}],"sharedWithAccounts":[{"aid":176592,"name":"Cloudreach"}],"domain": "webex.com","dnsTransportProtocol":  "UDP"}]"apiLinks":[{"rel":"self","href":"https://api.thousandeyes.com/v6/tests/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/web/dns-trace/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/metrics/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/path-vis/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/bgp-metrics/1226221"}]}]}`
+	setup()
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	mux.HandleFunc("/tests/122621.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		_, _ = w.Write([]byte(out))
+	})
+	_, err := client.GetFTPServer(122621)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Could not decode JSON response: invalid character 'c' looking for beginning of object key string")
+}
+
+func TestClient_CreateFTPServer(t *testing.T) {
+	out := `{"test":[{"createdDate":"2020-02-06 15:28:07","createdBy":"William Fleming (wfleming@grumpysysadm.com)","enabled":1,"savedEvent":0,"testId":122621,"testName":"test123","type":"ftp-server","alertsEnabled":1,"liveShare":0,"probeMode":"AUTO","agents":[{"agentId":48620,"agentName":"Seattle, WA (Trial) - IPv6","agentType":"Cloud","countryId":"US","ipAddresses":["135.84.184.153"],"location":"Seattle Area","network":"Astute Hosting Inc. (AS 54527)","prefix":"135.84.184.0/22"}],"sharedWithAccounts":[{"aid":176592,"name":"Cloudreach"}],"domain": "url.com","apiLinks":[{"rel":"self","href":"https://api.thousandeyes.com/v6/tests/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/web/ftp-server/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/metrics/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/path-vis/1226221"},{"rel":"data","href":"https://api.thousandeyes.com/v6/net/bgp-metrics/1226221"}]}]}`
+	setup()
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	mux.HandleFunc("/tests/ftp-server/new.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(out))
+	})
+
+	// Define expected values from the API (based on the JSON we print out above)
+	expected := FTPServer{
+		TestID:        122621,
+		Enabled:       1,
+		CreatedBy:     "William Fleming (wfleming@grumpysysadm.com)",
+		CreatedDate:   "2020-02-06 15:28:07",
+		SavedEvent:    0,
+		TestName:      "test123",
+		Type:          "ftp-server",
+		AlertsEnabled: 1,
+		Url:           "webex.com",
+		Protocol:      "TCP",
+		Agents: []Agent{
+			{
+				AgentId:     48620,
+				AgentType:   "Cloud",
+				AgentName:   "Seattle, WA (Trial) - IPv6",
+				CountryId:   "US",
+				IpAddresses: []string{"135.84.184.153"},
+				Location:    "Seattle Area",
+				Network:     "Astute Hosting Inc. (AS 54527)",
+				Prefix:      "135.84.184.0/22",
+			},
+		},
+		SharedWithAccounts: []AccountGroup{
+			{
+				Aid:  176592,
+				Name: "Cloudreach",
+			},
+		},
+
+		APILinks: []ApiLink{
+			{
+				Href: "https://api.thousandeyes.com/v6/tests/1226221",
+				Rel:  "self",
+			},
+			{
+				Href: "https://api.thousandeyes.com/v6/web/ftp-server/1226221",
+				Rel:  "data",
+			},
+			{
+				Href: "https://api.thousandeyes.com/v6/net/metrics/1226221",
+				Rel:  "data",
+			},
+			{
+				Href: "https://api.thousandeyes.com/v6/net/path-vis/1226221",
+				Rel:  "data",
+			},
+			{
+				Href: "https://api.thousandeyes.com/v6/net/bgp-metrics/1226221",
+				Rel:  "data",
+			},
+		},
+	}
+	create := DNSTrace{
+		TestName: "test1",
+		Domain:   "1.1.1.1",
+		Interval: 300,
+	}
+	res, err := client.CreateDNSTrace(create)
+	teardown()
+	assert.Nil(t, err)
+	assert.Equal(t, &expected, res)
+}
+
+func TestClient_DeleteFTPServer(t *testing.T) {
+	setup()
+
+	mux.HandleFunc("/tests/ftp-server/1/delete.json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+		assert.Equal(t, "POST", r.Method)
+	})
+
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	id := 1
+	err := client.DeleteFTPServer(id)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_AddFTPServerAlertRule(t *testing.T) {
+	test := FTPServer{TestName: "test", AlertRules: []AlertRule{}}
+	expected := FTPServer{TestName: "test", AlertRules: []AlertRule{{RuleId: 1}}}
+	test.AddAlertRule(1)
+	assert.Equal(t, expected, test)
+}
+
+func TestClient_UpdateFTPServer(t *testing.T) {
+	setup()
+	out := `{"test":[{"testId":1,"testName":"test123","type":"ftp-server","url":"webex.com" }]}`
+	mux.HandleFunc("/tests/ftp-server/1/update.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		_, _ = w.Write([]byte(out))
+	})
+
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	id := 1
+	ftpServer := FTPServer{Url: "webex.com"}
+	res, err := client.UpdateFTPServer(id, ftpServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := FTPServer{TestID: 1, TestName: "test123", Type: "ftp-server", Url: "webex.com"}
+	assert.Equal(t, &expected, res)
+
+}
+
+func TestFTPServer_AddAgent(t *testing.T) {
+	test := FTPServer{TestName: "test", Agents: Agents{}}
+	expected := FTPServer{TestName: "test", Agents: []Agent{{AgentId: 1}}}
+	test.AddAgent(1)
+	assert.Equal(t, expected, test)
+}
+
+func TestClient_GetFTPServerError(t *testing.T) {
+	setup()
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	mux.HandleFunc("/tests/ftp-server/1.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	_, err := client.GetFTPServer(1)
+	teardown()
+	assert.Error(t, err)
+}
+
+func TestClient_GetFTPServerStatusCode(t *testing.T) {
+	setup()
+	out := `{"test":[{"testId":1,"testName":"test123","type":"ftp-server"}]}`
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	mux.HandleFunc("/tests/1.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(out))
+	})
+
+	_, err := client.GetFTPServer(1)
+	teardown()
+	assert.EqualError(t, err, "Failed call API endpoint. HTTP response code: 400. Error: &{}")
+}
+
+func TestClient_CreateFTPServerStatusCode(t *testing.T) {
+	setup()
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	mux.HandleFunc("/tests/ftp-server/new.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{}`))
+	})
+	_, err := client.CreateFTPServer(FTPServer{})
+	teardown()
+	assert.EqualError(t, err, "Failed call API endpoint. HTTP response code: 400. Error: &{}")
+}
+
+func TestClient_UpdateFTPServerStatusCode(t *testing.T) {
+	setup()
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	mux.HandleFunc("/tests/ftp-server/1/update.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{}`))
+	})
+	_, err := client.UpdateFTPServer(1, FTPServer{})
+	teardown()
+	assert.EqualError(t, err, "Failed call API endpoint. HTTP response code: 400. Error: &{}")
+}
+
+func TestClient_DeleteFTPServerCode(t *testing.T) {
+	setup()
+	var client = &Client{ApiEndpoint: server.URL, AuthToken: "foo"}
+	mux.HandleFunc("/tests/ftp-server/1/delete.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{}`))
+	})
+	err := client.DeleteFTPServer(1)
+	teardown()
+	assert.EqualError(t, err, "Failed call API endpoint. HTTP response code: 400. Error: &{}")
+}


### PR DESCRIPTION
## What

* ftp-server test support

## Why

* Get all test types supported before #32 starts