### PR TITLE
fix(dscpId): remove the omit from marshall on dscpId

### DIFF
--- a/agent_agent.go
+++ b/agent_agent.go
@@ -17,7 +17,7 @@ type AgentAgent struct {
 	Description            string         `json:"description,omitempty"`
 	Direction              string         `json:"direction,omitempty"`
 	Dscp                   string         `json:"dscp,omitempty"`
-	DscpID                 int            `json:"dscpId,omitempty"`
+	DscpID                 int            `json:"dscpId"`
 	Enabled                int            `json:"enabled,omitempty"`
 	Groups                 []GroupLabel   `json:"groups,omitempty"`
 	Interval               int            `json:"interval,omitempty"`


### PR DESCRIPTION
## What

* This accepts `0` so `omitempty` ignores this field when you try to set dscp

## Why

* When creating AgentAgent tests it cause havoc ignoring this field william20111/terraform-provider-thousandeyes#14 