### PR TITLE
fix(goreleaser): include windows builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,3 +14,7 @@ builds:
       - -s -w -X main.build={{.Version}}
     goarch:
       - amd64
+    goos:
+      - windows
+      - linux
+      - darwin


### PR DESCRIPTION
## What

* windows included in default builds

## Why

* windows users now included in CI builds