### PR TITLE
feat(account-groups) Support sending account group

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,16 +33,18 @@ type HTTPClient interface {
 
 // Client wraps http client
 type Client struct {
-	AuthToken   string
-	APIEndpoint string
-	HTTPClient  http.Client
+	AuthToken      string
+	AccountGroupID string
+	APIEndpoint    string
+	HTTPClient     http.Client
 }
 
 // NewClient creates an API client
-func NewClient(authToken string) *Client {
+func NewClient(authToken string, accountGroupID string) *Client {
 	return &Client{
-		AuthToken:   authToken,
-		APIEndpoint: apiEndpoint,
+		AuthToken:      authToken,
+		AccountGroupID: accountGroupID,
+		APIEndpoint:    apiEndpoint,
 		HTTPClient: http.Client{
 			Timeout: time.Second * 10,
 		},
@@ -79,6 +81,11 @@ func (c *Client) get(path string) (*http.Response, error) {
 func (c *Client) do(method, path string, body io.Reader, headers *map[string]string) (*http.Response, error) {
 	endpoint := c.APIEndpoint + path + ".json"
 	req, _ := http.NewRequest(method, endpoint, body)
+	if c.AccountGroupID != "" {
+		q := req.URL.Query()
+		q.Add("aid", c.AccountGroupID)
+		req.URL.RawQuery = q.Encode()
+	}
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", c.AuthToken))
 	req.Header.Set("content-type", "application/json")

--- a/client_test.go
+++ b/client_test.go
@@ -20,7 +20,8 @@ func setup() {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 	var authToken = "foo"
-	client = NewClient(authToken)
+	var accountGroup = "bar"
+	client = NewClient(authToken, accountGroup)
 }
 
 func teardown() {

--- a/command/tectl/cmd/agents.go
+++ b/command/tectl/cmd/agents.go
@@ -2,15 +2,16 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/olekukonko/tablewriter"
-	"github.com/william20111/go-thousandeyes"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/william20111/go-thousandeyes"
 )
 
 func GetAgentsExecute() error {
-	client := thousandeyes.NewClient(os.Getenv("TE_TOKEN"))
+	client := thousandeyes.NewClient(os.Getenv("TE_TOKEN"), os.Getenv("TE_AID"))
 	var table *tablewriter.Table
 	if GetCmd.Flags().Changed("id") {
 		id, err := GetCmd.Flags().GetString("id")

--- a/command/tectl/cmd/tests.go
+++ b/command/tectl/cmd/tests.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/william20111/go-thousandeyes"
-	"os"
-	"strconv"
 )
 
 var TestsCmd = &cobra.Command{
@@ -23,7 +24,7 @@ var TestsCmd = &cobra.Command{
 }
 
 func GetTestsExecute() error {
-	client := thousandeyes.NewClient(os.Getenv("TE_TOKEN"))
+	client := thousandeyes.NewClient(os.Getenv("TE_TOKEN"), os.Getenv("TE_AID"))
 	var table *tablewriter.Table
 	if GetCmd.Flags().Changed("id") {
 		id, err := GetCmd.Flags().GetString("id")


### PR DESCRIPTION
This adds support for sending the account group ID to differentiate between multiple accounts accessible by a single user token.