### PR TITLE
feat(client): client rate limiter option

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -102,7 +101,7 @@ func (c *Client) get(path string) (*http.Response, error) {
 }
 
 func (c *Client) do(method, path string, body io.Reader, headers *map[string]string) (*http.Response, error) {
-	if !reflect.ValueOf(c.Limiter).IsNil() {
+	if c.Limiter != nil {
 		c.Limiter.Wait()
 	}
 	endpoint := c.APIEndpoint + path + ".json"

--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ type errorObject struct {
 	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
+// Limiter - Rate limiter interface
 type Limiter interface {
 	Wait()
 }

--- a/client.go
+++ b/client.go
@@ -26,9 +26,19 @@ type errorObject struct {
 	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
+type Limiter interface {
+	Wait()
+}
+
 //HTTPClient - an http client
 type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
+}
+
+type ClientOptions struct {
+	Limiter   Limiter
+	AccountID string
+	AuthToken string
 }
 
 // Client wraps http client
@@ -37,17 +47,26 @@ type Client struct {
 	AccountGroupID string
 	APIEndpoint    string
 	HTTPClient     http.Client
+	Limiter        Limiter
+}
+
+// default thousandeyes rate limit is 240 per minute
+type DefaultLimiter struct{}
+
+func (l DefaultLimiter) Wait() {
+	time.Sleep(time.Millisecond * 300)
 }
 
 // NewClient creates an API client
-func NewClient(authToken string, accountGroupID string) *Client {
+func NewClient(opts *ClientOptions) *Client {
 	return &Client{
-		AuthToken:      authToken,
-		AccountGroupID: accountGroupID,
+		AuthToken:      opts.AuthToken,
+		AccountGroupID: opts.AuthToken,
 		APIEndpoint:    apiEndpoint,
 		HTTPClient: http.Client{
 			Timeout: time.Second * 10,
 		},
+		Limiter: opts.Limiter,
 	}
 }
 
@@ -79,6 +98,9 @@ func (c *Client) get(path string) (*http.Response, error) {
 }
 
 func (c *Client) do(method, path string, body io.Reader, headers *map[string]string) (*http.Response, error) {
+	if c.Limiter != nil {
+		c.Limiter.Wait()
+	}
 	endpoint := c.APIEndpoint + path + ".json"
 	req, _ := http.NewRequest(method, endpoint, body)
 	if c.AccountGroupID != "" {

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -98,7 +99,7 @@ func (c *Client) get(path string) (*http.Response, error) {
 }
 
 func (c *Client) do(method, path string, body io.Reader, headers *map[string]string) (*http.Response, error) {
-	if c.Limiter != nil {
+	if !reflect.ValueOf(c.Limiter).IsNil() {
 		c.Limiter.Wait()
 	}
 	endpoint := c.APIEndpoint + path + ".json"

--- a/client.go
+++ b/client.go
@@ -36,6 +36,7 @@ type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
+// ClientOptions - Thousandeyes client options for accountID, AuthToken & rate limiter
 type ClientOptions struct {
 	Limiter   Limiter
 	AccountID string
@@ -51,9 +52,10 @@ type Client struct {
 	Limiter        Limiter
 }
 
-// default thousandeyes rate limit is 240 per minute
+// DefaultLimiter -  thousandeyes rate limit is 240 per minute
 type DefaultLimiter struct{}
 
+// Wait - Satisfying the Limiter interface and wait on 300ms to avoid TE 240 per minute default
 func (l DefaultLimiter) Wait() {
 	time.Sleep(time.Millisecond * 300)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,8 @@ func setup() {
 	server = httptest.NewServer(mux)
 	var authToken = "foo"
 	var accountGroup = "bar"
-	client = NewClient(authToken, accountGroup)
+	clientOpts := ClientOptions{AuthToken: authToken, AccountID: accountGroup}
+	client = NewClient(&clientOpts)
 }
 
 func teardown() {


### PR DESCRIPTION
## Summary

* Keep it stupid simple and provide an optional rate limit interface on the client to delay calls and avoid any rate limiting. This can be then implemented by the consumer rather than any decisions made by library for the consumer
* BREAKING CHANGE: changes the client options to config struct