### PR TITLE
Rate limiting

### DIFF
--- a/client.go
+++ b/client.go
@@ -264,5 +264,5 @@ func storeLimits(req *http.Request, resp *http.Response) {
 }
 
 func isInstantTest(req *http.Request) bool {
-	return strings.HasPrefix(req.URL.RawPath, "/v6/instant") == true || strings.HasPrefix(req.URL.RawPath, "/v6/endpoint-instant")
+	return strings.HasPrefix(req.URL.Path, "/v6/instant") == true || strings.HasPrefix(req.URL.Path, "/v6/endpoint-instant")
 }

--- a/client.go
+++ b/client.go
@@ -5,13 +5,31 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 )
 
 const (
 	apiEndpoint = "https://api.thousandeyes.com/v6"
 )
+
+var orgRate RateLimit
+var instantTestRate RateLimit
+
+// RateLimit contains data representing rate limit headers returned in
+// ThousandEyes API responses.  int64 everywhere for ease of interacting
+// with time values.
+type RateLimit struct {
+	Limit              int64
+	Remaining          int64
+	Reset              int64
+	LastRemaining      int64
+	LastTime           time.Time
+	ConcurrentMessages int64
+}
 
 // APILinks - List of APILink
 type APILinks []APILink
@@ -94,7 +112,26 @@ func (c *Client) do(method, path string, body io.Reader, headers *map[string]str
 			req.Header.Set(k, v)
 		}
 	}
+
+	// Perform any delays required by previously observed rate headers
+	delay := setDelay(req, nil)
+	time.Sleep(delay)
+
 	resp, err := c.HTTPClient.Do(req)
+
+	// Store reported rate limit status
+	storeLimits(req, resp)
+
+	// If request was rate limited, back off and retry.
+	// We shouldn't typically need to do this, because the above delays should
+	// prevent us from hitting the limit, but there may be other users in an
+	// org who might have triggered the limiting.
+	if resp.StatusCode == 429 {
+		delay := setDelay(req, resp)
+		time.Sleep(delay)
+		resp, err = c.HTTPClient.Do(req)
+	}
+
 	return c.checkResponse(resp, err)
 }
 
@@ -125,4 +162,102 @@ func (c *Client) getErrorFromResponse(resp *http.Response) (*errorObject, error)
 		return nil, fmt.Errorf("Could not decode JSON response: %v", err)
 	}
 	return &result, nil
+}
+
+// setDelay determines the pause time needed to prevent invoking rate limiting
+func setDelay(req *http.Request, resp *http.Response) time.Duration {
+	// Choose which rate limit applies
+	var delay time.Duration
+	var rate RateLimit
+	now := time.Now()
+	instantTest := isInstantTest(req)
+	if instantTest {
+		rate = instantTestRate
+	} else {
+		rate = orgRate
+	}
+
+	// If the limit is 0, this is either our first request or we are not receiving
+	// rate limit data in the headers
+	if rate.Limit == 0 {
+		return 0
+	}
+
+	// If this is the first time we've sent this particular request and we
+	// aren't at the end of our remaining requests for the period...
+	if resp == nil && rate.Remaining > 1 {
+		baseDelay := 1.0 / float64(rate.Limit) * float64(time.Minute.Nanoseconds())
+		// Requests may not be sent synchroniously, so we need to calculate the ratio of
+		// actual time elapsed to expected delay per message.
+		sinceLast := float64(now.Sub(rate.LastTime).Nanoseconds())
+		// The rate limit is per minute, so if there was a zero response time
+		// then the ideal delay would be the one minute divided by the rate.
+		// To account for potential other users, we will multiply by the
+		// difference between the remaining count and our last seen remaining
+		// count.
+		delta := rate.LastRemaining - rate.Remaining
+		if delta < 1 {
+			delta = 1
+		}
+
+		// It's possible that these calls could be made concurrently, in which
+		// case the pacing delay would effectively be divided by the batch size.
+		// To account for this, we compare the number of messages issued in a
+		// window smaller than the base delay and increase accordingly.
+		if sinceLast < baseDelay {
+			rate.ConcurrentMessages++
+			delta += rate.ConcurrentMessages
+		} else {
+			rate.ConcurrentMessages = 0
+		}
+		delay = time.Duration(baseDelay * float64(delta))
+		log.Printf("[INFO] %v of %v requests / min remain.  Sleeping %v to prevent rate limiting.",
+			rate.Remaining, rate.Limit, delay)
+	} else {
+		// else calculate delay until resume time.
+		// Assume our clock is roughly in sync with the clock setting the resume time.
+		delay = time.Duration((rate.Reset - now.Unix() + 1) * time.Second.Nanoseconds())
+		log.Printf("[INFO] Rate Limited: Sleeping %v before resubmitting\n", delay)
+	}
+	if instantTest {
+		instantTestRate.LastTime = now
+		instantTestRate.ConcurrentMessages = rate.ConcurrentMessages
+	} else {
+		orgRate.LastTime = now
+		orgRate.ConcurrentMessages = rate.ConcurrentMessages
+	}
+	return delay
+}
+
+// storeLimits assigns the global variables to track current rate limit data
+func storeLimits(req *http.Request, resp *http.Response) {
+	// We discard errors, because an error or blank result also return 0
+	if v := resp.Header.Get("X-Organization-Rate-Limit-Limit"); v != "" {
+		orgRate.Limit, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if v := resp.Header.Get("X-Organization-Rate-Limit-Remaining"); v != "" {
+		orgRate.Remaining, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if v := resp.Header.Get("X-Organization-Rate-Limit-Reset"); v != "" {
+		orgRate.Reset, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if v := resp.Header.Get("X-Instant-Test-Rate-Limit-Limit"); v != "" {
+		instantTestRate.Limit, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if v := resp.Header.Get("X-Instant-Test-Rate-Limit-Remaining"); v != "" {
+		instantTestRate.Remaining, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if v := resp.Header.Get("X-Instant-Test-Rate-Limit-Reset"); v != "" {
+		instantTestRate.Reset, _ = strconv.ParseInt(v, 10, 64)
+	}
+
+	if isInstantTest(req) {
+		instantTestRate.LastTime = time.Now()
+	} else {
+		orgRate.LastTime = time.Now()
+	}
+}
+
+func isInstantTest(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.RawPath, "/v6/instant") == true || strings.HasPrefix(req.URL.RawPath, "/v6/endpoint-instant")
 }

--- a/client.go
+++ b/client.go
@@ -228,10 +228,8 @@ func setDelay(req *http.Request, resp *http.Response) time.Duration {
 		log.Printf("[INFO] Rate Limited: Sleeping %v before resubmitting\n", delay)
 	}
 	if instantTest {
-		instantTestRate.LastTime = now
 		instantTestRate.ConcurrentMessages = rate.ConcurrentMessages
 	} else {
-		orgRate.LastTime = now
 		orgRate.ConcurrentMessages = rate.ConcurrentMessages
 	}
 	return delay

--- a/client.go
+++ b/client.go
@@ -217,6 +217,11 @@ func setDelay(req *http.Request, resp *http.Response) time.Duration {
 		// else calculate delay until resume time.
 		// Assume our clock is roughly in sync with the clock setting the resume time.
 		delay = time.Duration((rate.Reset - now.Unix() + 1) * time.Second.Nanoseconds())
+		// ThousandEyes rates reset within one minute (but not guaranteed).
+		// If we exceed a minute wait time, something may be wrong.
+		if delay > time.Minute {
+			delay = time.Minute
+		}
 		log.Printf("[INFO] Rate Limited: Sleeping %v before resubmitting\n", delay)
 	}
 	if instantTest {

--- a/client_test.go
+++ b/client_test.go
@@ -82,6 +82,8 @@ func Test_setDelay(t *testing.T) {
 		LastTime:           now.Add(-1 * time.Nanosecond),
 		ConcurrentMessages: 3,
 	}
+	// Use state to test instant test below
+	instantTestRate = orgRate
 	delay = setDelay(req, nil)
 	assert.Equal(t, 2*time.Second, delay)
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,10 +1,12 @@
 package thousandeyes
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -50,4 +52,104 @@ func Test_ClientAccountGroupNone(t *testing.T) {
 		_, _ = w.Write([]byte(out))
 	})
 	_, _ = client.GetAgents()
+}
+
+func Test_setDelay(t *testing.T) {
+	setup()
+	now := time.Now()
+
+	var delay time.Duration
+	var req *http.Request
+	var resp *http.Response
+	orgRate = RateLimit{}
+	instantTestRate = RateLimit{}
+	req, _ = http.NewRequest("GET", "https://api.thousandeyes.com/v6/agents.json", nil)
+	resp = &http.Response{}
+	resp.Header = make(map[string][]string)
+
+	// Test initial requests, for which rate limit data is not available
+	orgRate = RateLimit{}
+	delay = setDelay(req, nil)
+	assert.Equal(t, time.Duration(0), delay)
+
+	// Test subsequent requests with rate limit data
+	// All complications:
+	orgRate = RateLimit{
+		Limit:              240,
+		Remaining:          100,
+		Reset:              now.Add(30 * time.Second).Unix(),
+		LastRemaining:      104,
+		LastTime:           now.Add(-1 * time.Nanosecond),
+		ConcurrentMessages: 3,
+	}
+	delay = setDelay(req, nil)
+	assert.Equal(t, 2*time.Second, delay)
+
+	// LastTime over the minimum delay time should result in the minimum delay time if there
+	// are no concurrent messages and last remaining has not decreased by more than 1.
+	orgRate.LastRemaining = 101
+	orgRate.ConcurrentMessages = 0
+	orgRate.LastTime = now.Add(-5 * time.Second)
+	delay = setDelay(req, nil)
+	assert.Equal(t, time.Duration(250*time.Millisecond), delay)
+
+	// A passed response means we should delay, as this is presently only done
+	// in response to a 429
+	resp.StatusCode = 429
+	delay = setDelay(req, resp)
+	assert.Equal(t, 31*time.Second, delay)
+
+	// Remaining messages being under the minimum should also result in waiting
+	// until reset
+	orgRate.Remaining = 1
+	delay = setDelay(req, nil)
+	assert.Equal(t, 31*time.Second, delay)
+
+}
+
+func Test_storeLimits(t *testing.T) {
+	setup()
+	now := time.Now()
+	destRate := RateLimit{
+		Limit:     240,
+		Remaining: 2,
+		Reset:     120,
+		LastTime:  now,
+	}
+
+	var req *http.Request
+	var resp *http.Response
+	orgRate = RateLimit{}
+	instantTestRate = RateLimit{}
+	req, _ = http.NewRequest("GET", "https://api.thousandeyes.com/v6/agents.json", nil)
+	resp = &http.Response{}
+	resp.Header = make(map[string][]string)
+	resp.Header.Add("X-Organization-Rate-Limit-Limit", "240")
+	resp.Header.Add("X-Organization-Rate-Limit-Remaining", "2")
+	resp.Header.Add("X-Organization-Rate-Limit-Reset", "120")
+	storeLimits(req, resp, now)
+	assert.Equal(t, destRate, orgRate)
+	assert.Equal(t, RateLimit{}, instantTestRate)
+
+	orgRate = RateLimit{}
+	instantTestRate = RateLimit{}
+	req, _ = http.NewRequest("GET", "https://api.thousandeyes.com/v6/instant/agent-to-server.json", nil)
+	resp = &http.Response{}
+	resp.Header = make(map[string][]string)
+	resp.Header.Add("X-Instant-Test-Rate-Limit-Limit", "240")
+	resp.Header.Add("X-Instant-Test-Rate-Limit-Remaining", "2")
+	resp.Header.Add("X-Instant-Test-Rate-Limit-Reset", "120")
+	storeLimits(req, resp, now)
+	assert.Equal(t, destRate, instantTestRate)
+	assert.Equal(t, RateLimit{}, orgRate)
+}
+
+func Test_isInstantTest(t *testing.T) {
+	var req *http.Request
+	req, _ = http.NewRequest("GET", "https://api.thousandeyes.com/v6/instant/agent-to-server.json", nil)
+	assert.Equal(t, true, isInstantTest(req))
+	req, _ = http.NewRequest("GET", "https://api.thousandeyes.com/v6/endpoint-instant/agent-to-server.json", nil)
+	assert.Equal(t, true, isInstantTest(req))
+	req, _ = http.NewRequest("GET", "https://api.thousandeyes.com/v6/agents.json", nil)
+	assert.Equal(t, false, isInstantTest(req))
 }


### PR DESCRIPTION
Based on prior conversation on [the previous PR](https://github.com/william20111/go-thousandeyes/pull/64) indicating being open to the possibilty, I am re-submitting this branch for reconsideration.

The purpose of this is not to enforce client-side rate limiting, but to comply with rate limiting when the server reports that it is being imposed (which is always when ThousandEyes is operating correctly).  Rate limiting is enforced on an org-wide basis by ThousandEyes, so a single client's voluntary rate limiting would not necessarily prevent overrunning a rate limit.

An additional change is included in this submission to handle inconsistent response formation from ThousandEyes.