### PR TITLE
fix: Correct type for customHeaders field

### DIFF
--- a/http_server.go
+++ b/http_server.go
@@ -9,6 +9,12 @@ type HTTPServerResponse struct {
 	tests []HTTPServer
 }
 
+type CustomHeaders struct {
+	Root    map[string]string            `json:"root,omitempty"`
+	All     map[string]string            `json:"all,omitempty"`
+	Domains map[string]map[string]string `json:"domains,omitempty"`
+}
+
 // HTTPServer - a http server test
 type HTTPServer struct {
 	// Common test fields
@@ -30,39 +36,39 @@ type HTTPServer struct {
 	// LiveShare is common to all tests except DNS+
 	LiveShare int `json:"liveShare,omitempty"`
 	// Fields unique to this test
-	Agents                Agents              `json:"agents,omitempty"`
-	AuthType              string              `json:"authType,omitempty"`
-	BandwidthMeasurements int                 `json:"bandwidthMeasurements,omitempty"`
-	BGPMeasurements       int                 `json:"bgpMeasurements,omitempty"`
-	BGPMonitors           []Monitor           `json:"bgpMonitors,omitempty"`
-	CustomHeaders         []map[string]string `json:"customHeaders,omitempty"`
-	ClientCertificate     string              `json:"clientCertificate,omitempty"`
-	ContentRegex          string              `json:"contentRegex,omitempty"`
-	DesiredStatusCode     string              `json:"desiredStatusCode,omitempty"`
-	DownloadLimit         string              `json:"downloadLimit,omitempty"`
-	DNSOverride           string              `json:"dnsOverride,omitempty"`
-	FollowRedirects       int                 `json:"followRedirects,omitempty"`
-	Headers               []string            `json:"headers,omitempty"`
-	HTTPVersion           int                 `json:"httpVersion,omitempty"`
-	HTTPTargetTime        int                 `json:"httpTargetTime,omitempty"`
-	HTTPTimeLimit         int                 `json:"httpTimeLimit,omitempty"`
-	Interval              int                 `json:"interval,omitempty"`
-	MTUMeasurements       int                 `json:"mtuMeasurements,omitempty"`
-	NetworkMeasurements   int                 `json:"networkMeasurements,omitempty"`
-	NumPathTraces         int                 `json:"numPathTraces,omitempty"`
-	Password              string              `json:"password,omitempty"`
-	PathTraceMode         string              `json:"pathTraceMode,omitempty"`
-	PostBody              string              `json:"postBody,omitempty"`
-	ProbeMode             string              `json:"probeMode,omitempty"`
-	Protocol              string              `json:"protocol,omitempty"`
-	SSLVersion            string              `json:"sslVersion,omitempty"`
-	SSLVersionID          int                 `json:"sslVersionId,omitempty"`
-	URL                   string              `json:"url,omitempty"`
-	UseNTLM               int                 `json:"useNtlm,omitempty"`
-	UsePublicBGP          int                 `json:"usePublicBgp,omitempty"`
-	UserAgent             string              `json:"userAgent,omitempty"`
-	Username              string              `json:"username,omitempty"`
-	VerifyCertificate     int                 `json:"verifyCertificate,omitempty"`
+	Agents                Agents        `json:"agents,omitempty"`
+	AuthType              string        `json:"authType,omitempty"`
+	BandwidthMeasurements int           `json:"bandwidthMeasurements,omitempty"`
+	BGPMeasurements       int           `json:"bgpMeasurements,omitempty"`
+	BGPMonitors           []Monitor     `json:"bgpMonitors,omitempty"`
+	ClientCertificate     string        `json:"clientCertificate,omitempty"`
+	ContentRegex          string        `json:"contentRegex,omitempty"`
+	CustomHeaders         CustomHeaders `json:"customHeaders,omitempty"`
+	DesiredStatusCode     string        `json:"desiredStatusCode,omitempty"`
+	DownloadLimit         string        `json:"downloadLimit,omitempty"`
+	DNSOverride           string        `json:"dnsOverride,omitempty"`
+	FollowRedirects       int           `json:"followRedirects,omitempty"`
+	Headers               []string      `json:"headers,omitempty"`
+	HTTPVersion           int           `json:"httpVersion,omitempty"`
+	HTTPTargetTime        int           `json:"httpTargetTime,omitempty"`
+	HTTPTimeLimit         int           `json:"httpTimeLimit,omitempty"`
+	Interval              int           `json:"interval,omitempty"`
+	MTUMeasurements       int           `json:"mtuMeasurements,omitempty"`
+	NetworkMeasurements   int           `json:"networkMeasurements,omitempty"`
+	NumPathTraces         int           `json:"numPathTraces,omitempty"`
+	Password              string        `json:"password,omitempty"`
+	PathTraceMode         string        `json:"pathTraceMode,omitempty"`
+	PostBody              string        `json:"postBody,omitempty"`
+	ProbeMode             string        `json:"probeMode,omitempty"`
+	Protocol              string        `json:"protocol,omitempty"`
+	SSLVersion            string        `json:"sslVersion,omitempty"`
+	SSLVersionID          int           `json:"sslVersionId,omitempty"`
+	URL                   string        `json:"url,omitempty"`
+	UseNTLM               int           `json:"useNtlm,omitempty"`
+	UsePublicBGP          int           `json:"usePublicBgp,omitempty"`
+	UserAgent             string        `json:"userAgent,omitempty"`
+	Username              string        `json:"username,omitempty"`
+	VerifyCertificate     int           `json:"verifyCertificate,omitempty"`
 }
 
 // AddAgent - add an agent

--- a/http_server.go
+++ b/http_server.go
@@ -9,6 +9,8 @@ type HTTPServerResponse struct {
 	tests []HTTPServer
 }
 
+// CustomHeaders represents the JSON object exchanged for specifying
+// custom HTTP headers in HTTP Server, Page Load, and Web Transaction tests.
 type CustomHeaders struct {
 	Root    map[string]string            `json:"root,omitempty"`
 	All     map[string]string            `json:"all,omitempty"`

--- a/page_load.go
+++ b/page_load.go
@@ -25,37 +25,38 @@ type PageLoad struct {
 	// LiveShare is common to all tests except DNS+
 	LiveShare int `json:"liveShare,omitempty"`
 	// Fields unique to this test
-	Agents                Agents       `json:"agents,omitempty"`
-	AuthType              string       `json:"authType,omitempty"`
-	BandwidthMeasurements int          `json:"bandwidthMeasurements,omitempty"`
-	BGPMeasurements       int          `json:"bgpMeasurements,omitempty"`
-	BGPMonitors           []BGPMonitor `json:"bgpMonitors,omitempty"`
-	ContentRegex          string       `json:"contentRegex,omitempty"`
-	FollowRedirects       int          `json:"followRedirects,omitempty"`
-	HTTPInterval          int          `json:"httpInterval,omitempty"`
-	HTTPTargetTime        int          `json:"httpTargetTime,omitempty"`
-	HTTPTimeLimit         int          `json:"httpTimeLimit,omitempty"`
-	HTTPVersion           int          `json:"httpVersion,omitempty"`
-	IncludeHeaders        int          `json:"includeHeaders,omitempty"`
-	Interval              int          `json:"interval,omitempty"`
-	MTUMeasurements       int          `json:"mtuMeasurements,omitempty"`
-	NetworkMeasurements   int          `json:"networkMeasurements,omitempty"`
-	NumPathTraces         int          `json:"numPathTraces,omitempty"`
-	PageLoadTargetTime    int          `json:"pageLoadTargetTime,omitempty"`
-	PageLoadTimeLimit     int          `json:"pageLoadTimeLimit,omitempty"`
-	Password              string       `json:"password,omitempty"`
-	PathTraceMode         string       `json:"pathTraceMode,omitempty"`
-	ProbeMode             string       `json:"probeMode,omitempty"`
-	Protocol              string       `json:"protocol,omitempty"`
-	SSLVersion            string       `json:"sslVersion,omitempty"`
-	SSLVersionID          int          `json:"sslVersionId,omitempty"`
-	Subinterval           int          `json:"subinterval,omitempty"`
-	URL                   string       `json:"url,omitempty"`
-	UseNTLM               int          `json:"useNtlm,omitempty"`
-	UsePublicBGP          int          `json:"usePublicBgp,omitempty"`
-	UserAgent             string       `json:"userAgent,omitempty"`
-	Username              string       `json:"username,omitempty"`
-	VerifyCertificate     int          `json:"verifyCertificate,omitempty"`
+	Agents                Agents        `json:"agents,omitempty"`
+	AuthType              string        `json:"authType,omitempty"`
+	BandwidthMeasurements int           `json:"bandwidthMeasurements,omitempty"`
+	BGPMeasurements       int           `json:"bgpMeasurements,omitempty"`
+	BGPMonitors           []BGPMonitor  `json:"bgpMonitors,omitempty"`
+	ContentRegex          string        `json:"contentRegex,omitempty"`
+	CustomHeaders         CustomHeaders `json:"customHeaders,omitempty"`
+	FollowRedirects       int           `json:"followRedirects,omitempty"`
+	HTTPInterval          int           `json:"httpInterval,omitempty"`
+	HTTPTargetTime        int           `json:"httpTargetTime,omitempty"`
+	HTTPTimeLimit         int           `json:"httpTimeLimit,omitempty"`
+	HTTPVersion           int           `json:"httpVersion,omitempty"`
+	IncludeHeaders        int           `json:"includeHeaders,omitempty"`
+	Interval              int           `json:"interval,omitempty"`
+	MTUMeasurements       int           `json:"mtuMeasurements,omitempty"`
+	NetworkMeasurements   int           `json:"networkMeasurements,omitempty"`
+	NumPathTraces         int           `json:"numPathTraces,omitempty"`
+	PageLoadTargetTime    int           `json:"pageLoadTargetTime,omitempty"`
+	PageLoadTimeLimit     int           `json:"pageLoadTimeLimit,omitempty"`
+	Password              string        `json:"password,omitempty"`
+	PathTraceMode         string        `json:"pathTraceMode,omitempty"`
+	ProbeMode             string        `json:"probeMode,omitempty"`
+	Protocol              string        `json:"protocol,omitempty"`
+	SSLVersion            string        `json:"sslVersion,omitempty"`
+	SSLVersionID          int           `json:"sslVersionId,omitempty"`
+	Subinterval           int           `json:"subinterval,omitempty"`
+	URL                   string        `json:"url,omitempty"`
+	UseNTLM               int           `json:"useNtlm,omitempty"`
+	UsePublicBGP          int           `json:"usePublicBgp,omitempty"`
+	UserAgent             string        `json:"userAgent,omitempty"`
+	Username              string        `json:"username,omitempty"`
+	VerifyCertificate     int           `json:"verifyCertificate,omitempty"`
 }
 
 // AddAgent  - add an aget

--- a/web_transaction.go
+++ b/web_transaction.go
@@ -25,35 +25,35 @@ type WebTransaction struct {
 	// LiveShare is common to all tests except DNS+
 	LiveShare int `json:"liveShare,omitempty"`
 	// Fields unique to this test
-	Agents                Agents              `json:"agents,omitempty"`
-	AuthType              string              `json:"authType,omitempty"`
-	BandwidthMeasurements int                 `json:"bandwidthMeasurements,omitempty"`
-	ContentRegex          string              `json:"contentRegex,omitempty"`
-	Credentials           []int               `json:"credentials,omitempty"`
-	CustomHeaders         []map[string]string `json:"customHeaders,omitempty"`
-	DesiredStatusCode     string              `json:"desiredStatusCode,omitempty"`
-	HTTPTargetTime        int                 `json:"httpTargetTime,omitempty"`
-	HTTPTimeLimit         int                 `json:"httpTimeLimit,omitempty"`
-	HTTPVersion           int                 `json:"httpVersion,omitempty"`
-	IncludeHeaders        int                 `json:"includeHeaders,omitempty"`
-	Interval              int                 `json:"interval,omitempty"`
-	MTUMeasurements       int                 `json:"mtuMeasurements,omitempty"`
-	NetworkMeasurements   int                 `json:"networkMeasurements,omitempty"`
-	NumPathTraces         int                 `json:"numPathTraces,omitempty"`
-	Password              string              `json:"password,omitempty"`
-	PathTraceMode         string              `json:"pathTraceMode,omitempty"`
-	ProbeMode             string              `json:"probeMode,omitempty"`
-	Protocol              string              `json:"protocol,omitempty"`
-	SSLVersionID          int                 `json:"sslVersionId,omitempty"`
-	SubInterval           int                 `json:"subinterval,omitempty"`
-	TargetTime            int                 `json:"targetTime,omitempty"`
-	TimeLimit             int                 `json:"timeLimit,omitempty"`
-	TransactionScript     string              `json:"transactionScript,omitempty"`
-	URL                   string              `json:"url,omitempty"`
-	UseNTLM               int                 `json:"useNtlm,omitempty"`
-	UserAgent             string              `json:"userAgent,omitempty"`
-	Username              string              `json:"username,omitempty"`
-	VerifyCertificate     int                 `json:"verifyCertificate,omitempty"`
+	Agents                Agents        `json:"agents,omitempty"`
+	AuthType              string        `json:"authType,omitempty"`
+	BandwidthMeasurements int           `json:"bandwidthMeasurements,omitempty"`
+	ContentRegex          string        `json:"contentRegex,omitempty"`
+	Credentials           []int         `json:"credentials,omitempty"`
+	CustomHeaders         CustomHeaders `json:"customHeaders,omitempty"`
+	DesiredStatusCode     string        `json:"desiredStatusCode,omitempty"`
+	HTTPTargetTime        int           `json:"httpTargetTime,omitempty"`
+	HTTPTimeLimit         int           `json:"httpTimeLimit,omitempty"`
+	HTTPVersion           int           `json:"httpVersion,omitempty"`
+	IncludeHeaders        int           `json:"includeHeaders,omitempty"`
+	Interval              int           `json:"interval,omitempty"`
+	MTUMeasurements       int           `json:"mtuMeasurements,omitempty"`
+	NetworkMeasurements   int           `json:"networkMeasurements,omitempty"`
+	NumPathTraces         int           `json:"numPathTraces,omitempty"`
+	Password              string        `json:"password,omitempty"`
+	PathTraceMode         string        `json:"pathTraceMode,omitempty"`
+	ProbeMode             string        `json:"probeMode,omitempty"`
+	Protocol              string        `json:"protocol,omitempty"`
+	SSLVersionID          int           `json:"sslVersionId,omitempty"`
+	SubInterval           int           `json:"subinterval,omitempty"`
+	TargetTime            int           `json:"targetTime,omitempty"`
+	TimeLimit             int           `json:"timeLimit,omitempty"`
+	TransactionScript     string        `json:"transactionScript,omitempty"`
+	URL                   string        `json:"url,omitempty"`
+	UseNTLM               int           `json:"useNtlm,omitempty"`
+	UserAgent             string        `json:"userAgent,omitempty"`
+	Username              string        `json:"username,omitempty"`
+	VerifyCertificate     int           `json:"verifyCertificate,omitempty"`
 }
 
 // CreateWebTransaction - Create a web transaction test


### PR DESCRIPTION
customHeaders field in ThousandEyes API is an object rather than a
string.  There is an undocumented customHeadersForm field which is an
escaped JSON string which might suffice for issues integrating with
this format.